### PR TITLE
Update upstream code URL

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -13,7 +13,7 @@ maintainers = ["eric_G"]
 license = "AGPL-3.0-or-later"
 website = "https://web.libera.chat/gamja/"
 demo = "https://web.libera.chat/gamja/"
-code = "https://sr.ht/~emersion/gamja/"
+code = "https://codeberg.org/emersion/gamja"
 
 [integration]
 yunohost = ">= 11.2.12"


### PR DESCRIPTION
Gamja has moved to Codeberg

## Problem

My version history scraper could not get upstream versions, because the URL was not working. After reviewing, I noted that the project is no longer on SourceHut.

## Solution

Update URL to new repo.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- na The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
